### PR TITLE
Fix CI badge to show only main branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI version](https://badge.fury.io/py/epub-cfi-toolkit.svg)](https://badge.fury.io/py/epub-cfi-toolkit)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
-[![CI](https://github.com/PagePalApp/epub-cfi-toolkit/workflows/CI/badge.svg)](https://github.com/PagePalApp/epub-cfi-toolkit/actions)
+[![CI](https://github.com/PagePalApp/epub-cfi-toolkit/workflows/CI/badge.svg?branch=main)](https://github.com/PagePalApp/epub-cfi-toolkit/actions?query=workflow%3ACI+branch%3Amain)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Python toolkit for extracting text from EPUB files using **EPUB Canonical Fragment Identifiers (CFIs)** with full CFI specification compliance.


### PR DESCRIPTION
## Summary
- Updates CI badge URL to include `?branch=main` parameter
- Updates actions link to filter CI workflow runs by main branch only
- Ensures CI badge shows relevant status instead of potentially irrelevant PR status

## Changes
- Modified README.md CI badge URL from showing all workflow runs to main branch only
- Updated corresponding actions link to maintain consistency

## Test plan
- [x] Verified badge URL renders correctly: `https://github.com/PagePalApp/epub-cfi-toolkit/workflows/CI/badge.svg?branch=main`
- [x] Verified actions link filters correctly: `https://github.com/PagePalApp/epub-cfi-toolkit/actions?query=workflow%3ACI+branch%3Amain`

Fixes #14