### PR TITLE
Align CI workflow checks with CD workflow to prevent deployment failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,13 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 epub_cfi_toolkit --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 epub_cfi_toolkit --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # run full flake8 check (matches CD workflow) - no exit-zero to catch all errors
+        flake8 epub_cfi_toolkit
     
     - name: Type check with mypy
       run: |
-        mypy epub_cfi_toolkit --ignore-missing-imports
+        # run mypy without --ignore-missing-imports (matches CD workflow)
+        mypy epub_cfi_toolkit
     
     - name: Test with pytest
       run: |


### PR DESCRIPTION
## Summary
- Removes `--exit-zero` from flake8 command to fail on style violations (matching CD workflow)
- Removes `--ignore-missing-imports` from mypy to catch import issues (matching CD workflow)
- Ensures CI workflow catches all issues that could cause CD pipeline to fail after merge

## Changes
- Modified `.github/workflows/ci.yml` flake8 step to use strict checking
- Modified mypy step to match CD workflow configuration
- Added comments explaining the alignment with CD workflow

## Test plan
- [x] Verified flake8 passes with current codebase: `flake8 epub_cfi_toolkit`
- [x] Verified mypy passes with current codebase: `mypy epub_cfi_toolkit`
- [x] CI workflow will be tested automatically when PR is created

Fixes #9